### PR TITLE
feat: add llms.txt and llms-full.txt support

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,9 @@
 const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
 
 const DEV_TO_USERNAME = 'carcruz';
+const SITE_URL = 'https://www.carcruz.dev';
 
 exports.sourceNodes = async ({ actions, reporter }) => {
   const { createNode } = actions;
@@ -96,4 +99,96 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
       context: { id: node.id },
     });
   });
+};
+
+// Strips MDX-only syntax (imports, JSX components) so prose reads cleanly as
+// plain markdown in llms-full.txt.
+const stripMdxSyntax = (body) =>
+  body
+    .split('\n')
+    .filter((line) => !/^import\s/.test(line.trim()))
+    .join('\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+
+const toLink = (node) =>
+  `- [${node.frontmatter.title}](${SITE_URL}${node.frontmatter.path}): ${node.frontmatter.description}`;
+
+const toSection = (node) =>
+  `## ${node.frontmatter.title}\n${SITE_URL}${node.frontmatter.path}\n\n${stripMdxSyntax(node.body)}`;
+
+exports.onPostBuild = async ({ graphql, reporter }) => {
+  const result = await graphql(`
+    query {
+      site {
+        siteMetadata {
+          title
+          description
+        }
+      }
+      posts: allMdx(
+        filter: { frontmatter: { path: { regex: "/blog/" }, hidden: { ne: true } } }
+        sort: { frontmatter: { order: DESC } }
+      ) {
+        edges {
+          node {
+            body
+            frontmatter {
+              path
+              title
+              description
+            }
+          }
+        }
+      }
+      projects: allMdx(
+        filter: { frontmatter: { path: { regex: "/projects/" }, hidden: { ne: true } } }
+        sort: { frontmatter: { order: ASC } }
+      ) {
+        edges {
+          node {
+            body
+            frontmatter {
+              path
+              title
+              description
+            }
+          }
+        }
+      }
+    }
+  `);
+
+  if (result.errors) {
+    reporter.panicOnBuild('🚨  ERROR: Loading "onPostBuild" query for llms.txt');
+    return;
+  }
+
+  const { title, description } = result.data.site.siteMetadata;
+  const posts = result.data.posts.edges.map(({ node }) => node);
+  const projects = result.data.projects.edges.map(({ node }) => node);
+
+  const llmsTxt = [
+    `# ${title}`,
+    '',
+    `> ${description}`,
+    '',
+    '## Blog',
+    ...posts.map(toLink),
+    '',
+    '## Projects',
+    ...projects.map(toLink),
+    '',
+  ].join('\n');
+
+  const llmsFullTxt =
+    [`# ${title}`, '', `> ${description}`].join('\n') +
+    '\n\n---\n\n' +
+    [...posts, ...projects].map(toSection).join('\n\n---\n\n');
+
+  fs.writeFileSync(path.join(__dirname, 'public', 'llms.txt'), llmsTxt);
+  fs.writeFileSync(path.join(__dirname, 'public', 'llms-full.txt'), llmsFullTxt);
+
+  reporter.info('Generated llms.txt and llms-full.txt');
 };


### PR DESCRIPTION
## Summary
- Adds an `onPostBuild` hook in `gatsby-node.js` that generates `public/llms.txt` (spec-compliant curated index of blog posts and projects, per llmstxt.org) and `public/llms-full.txt` (full content dump) on every build.
- Both files are derived from the same MDX/frontmatter data used to build the site, respecting the existing `hidden: true` flag (so Pounce, Travel Health Dashboard, and Pathways API stay excluded, same as the sitemap) and the same sort order as the live blog/projects pages.
- No hand-maintained file to keep in sync — new posts/projects automatically appear on the next build.

## Test plan
- [x] `yarn gatsby build` runs cleanly and logs "Generated llms.txt and llms-full.txt"
- [x] `public/llms.txt` renders a valid markdown index with title, description blockquote, and linked blog/project entries
- [x] `public/llms-full.txt` contains full post/project content with MDX import/JSX noise stripped
- [x] Hidden projects (`pounce`, `travel-health-dashboard`, `pathways-api`) correctly excluded from both files
- [ ] Confirm `https://www.carcruz.dev/llms.txt` and `/llms-full.txt` resolve after deploy